### PR TITLE
Added EWF Image Support using libewf and pytsk3

### DIFF
--- a/GA-Parser_v1_1.py
+++ b/GA-Parser_v1_1.py
@@ -33,8 +33,12 @@ import datetime
 import os
 
 # Needed for ewf support.
-import pyewf
-import pytsk3
+try:
+    ewf_available = True
+    import pyewf
+    import pytsk3
+except:
+    ewf_available = False
 
 #########################  Functions to process individual cookie values (utma, utmb and utmz)   ##########################
 
@@ -702,19 +706,20 @@ def process_utm_gif_ASCII(pattern, chunk):
 
 # From https://code.google.com/p/libewf/wiki/pyewf
 # Added by chapinb
-class Ewf_Img_Info(pytsk3.Img_Info):
-  def __init__(self, filename):
-    self.ewf_handle = pyewf.handle()
-    filenames = pyewf.glob(filename)
-    self.ewf_handle.open(filenames)
-    super(Ewf_Img_Info, self).__init__()
+if ewf_available:
+    class Ewf_Img_Info(pytsk3.Img_Info):
+      def __init__(self, filename):
+        self.ewf_handle = pyewf.handle()
+        filenames = pyewf.glob(filename)
+        self.ewf_handle.open(filenames)
+        super(Ewf_Img_Info, self).__init__()
 
-  def read(self, offset, size):
-    self.ewf_handle.seek(offset)
-    return self.ewf_handle.read(size)
+      def read(self, offset, size):
+        self.ewf_handle.seek(offset)
+        return self.ewf_handle.read(size)
 
-  def get_size(self):
-    return self.ewf_handle.get_media_size()
+      def get_size(self):
+        return self.ewf_handle.get_media_size()
 
 #########################  Main   ##########################
 
@@ -747,7 +752,8 @@ input_parser.add_option("--firefox", action="store_true", dest="firefox", help =
 input_parser.add_option("--ie", action="store_true", dest="ie", help = "choose one or more")
 input_parser.add_option("--gif",action = "store_true", dest="gif_cache", help = "choose one or more")
 input_parser.add_option("--apple", action="store_true", dest="apple", help = "choose one or more")
-input_parser.add_option("--ewf", action="store_true", dest="ewf", help = "Select this is the input file is EWF format. Libewf must be installeds")
+if ewf_available:
+    input_parser.add_option("--ewf", action="store_true", dest="ewf", help = "Select this is the input file is EWF format. Libewf must be installeds")
 (options,args)=input_parser.parse_args()
 
 chrome = options.chrome
@@ -757,7 +763,8 @@ ie = options.ie
 apple = options.apple
 output_folder = options.output
 directory = options.directory
-ewf_file = options.ewf
+if ewf_available:
+    ewf_file = options.ewf
 
 #no arguments given by user,exit
 if len(sys.argv) == 1:
@@ -772,11 +779,11 @@ if chrome != True and firefox != True and gif_cache != True and ie != True and a
 print options.output
 
 if "\\" in options.output:
-	seperator = "\\"
+    seperator = "\\"
 if '/' in options.output:
-	seperator = "/"
-	
-	
+    seperator = "/"
+    
+    
 #open files for output
 if chrome or firefox or ie or apple:
     output_utmz = open(output_folder + seperator + "utmz.tsv", "a")


### PR DESCRIPTION
Great presentation and tool for the Google Analytics Cookies! 

I remember that you had mentioned that it did not currently support EWF images. Using [libewf from Joachim Metz](https://code.google.com/p/libewf/wiki/pyewf), I was able to hand the data from the E01 images into the rest of the script as a raw image. 

I have tested and verified the data with single and split E01 files and tested and verified again with a raw image to ensure I didn't break anything in the steps. 
